### PR TITLE
Include `stdint.h`

### DIFF
--- a/src/MqttClient.h
+++ b/src/MqttClient.h
@@ -17,6 +17,7 @@
 
 /* External Includes */
 #include <stdarg.h>
+#include <stdint.h>
 /* Internal Includes */
 #include "MQTTPacket/MQTTPacket.h"
 


### PR DESCRIPTION
Fix build error after merge #37:
```
error: ‘uint8_t’ was not declared in this scope
```